### PR TITLE
Debug image classification errors

### DIFF
--- a/app.js
+++ b/app.js
@@ -89,9 +89,9 @@ let pipelineVision = null; // CLIP pipeline
 async function ensureModelLoaded() {
 	if (modelLoaded) return;
 	setModelStatus('baixando modelos…');
-	// Load Transformers.js dynamically
+	// Load Transformers.js dynamically (UMD build exposes window.transformers)
 	if (!window.transformers) {
-		await loadScript('https://cdn.jsdelivr.net/npm/@xenova/transformers@2.16.1');
+		await loadScript('https://cdn.jsdelivr.net/npm/@xenova/transformers@2.16.1/dist/transformers.min.js');
 	}
 	const { pipeline } = window.transformers;
 	setModelStatus('inicializando CLIP…');

--- a/index.html
+++ b/index.html
@@ -108,6 +108,6 @@
       <p>Funciona 100% no navegador. Modelos via Transformers.js (CLIP). Pronto para deploy estático (Vercel).</p>
     </footer>
 
-    <script type="module" src="./app.js"></script>
+    <script src="./app.js"></script>
   </body>
 </html>


### PR DESCRIPTION
Switch to UMD build for Transformers.js and load `app.js` as a classic script to resolve module loading errors.

The previous setup attempted to load an ES Module version of Transformers.js as a classic script, leading to a `SyntaxError: Unexpected token 'export'`. Consequently, `window.transformers` was never defined, causing a `TypeError` when `app.js` tried to destructure `pipeline`. This change loads the UMD build of Transformers.js, which correctly populates `window.transformers`, and ensures `app.js` is loaded as a classic script to properly access this global.

---
<a href="https://cursor.com/background-agent?bcId=bc-56c360ac-d314-4865-b24b-63684c13f678">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-56c360ac-d314-4865-b24b-63684c13f678">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

